### PR TITLE
Add Claude Code hooks and workflow documentation

### DIFF
--- a/.claude/hooks/enforce-single-pr.sh
+++ b/.claude/hooks/enforce-single-pr.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Hook to remind about single PR workflow preference
+
+# Read the JSON input from stdin
+INPUT=$(cat)
+
+# Extract tool name and parameters
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
+TOOL_PARAMS=$(echo "$INPUT" | jq -r '.params.command // empty')
+
+# Check if trying to create a new branch when one already exists
+if [[ "$TOOL_NAME" == "Bash" ]]; then
+    if [[ "$TOOL_PARAMS" == *"git checkout -b"* ]] || [[ "$TOOL_PARAMS" == *"git switch -c"* ]]; then
+        CURRENT_BRANCH=$(git branch --show-current 2>/dev/null)
+        if [[ "$CURRENT_BRANCH" != "main" ]] && [[ "$CURRENT_BRANCH" != "master" ]]; then
+            echo "[WORKFLOW REMINDER] Current branch: '$CURRENT_BRANCH'. User prefers single PR - consider using existing branch for related work." >&2
+        fi
+    fi
+
+    # Check if trying to create multiple PRs
+    if [[ "$TOOL_PARAMS" == *"gh pr create"* ]]; then
+        EXISTING_PR=$(gh pr list --author @me --state open --json number --jq '.[0].number' 2>/dev/null)
+        if [[ -n "$EXISTING_PR" ]]; then
+            echo "[WORKFLOW REMINDER] Open PR #$EXISTING_PR exists. User prefers single PR for all related work, even multi-step implementations." >&2
+        fi
+    fi
+fi
+
+# Always allow the operation (exit 0), just provide reminders
+exit 0

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -1,0 +1,58 @@
+# GitHub PR Workflow Preferences
+
+## Single PR Policy
+
+**IMPORTANT**: All related work should be combined into a single PR, even if the implementation is broken down into multiple logical steps.
+
+### Why Single PR?
+- Easier review process - all related changes in one place
+- Better context - reviewers see the complete picture
+- Simpler history - one merge commit for the feature
+- Reduced CI/CD runs - tests run once for all changes
+
+### How This Works
+
+When working on multi-step tasks:
+1. Create ONE feature branch at the start
+2. Make all commits to that single branch
+3. Push updates to the same PR as work progresses
+4. The PR description can be updated to reflect completed steps
+
+### Example Workflow
+
+```bash
+# Start of work - create ONE branch
+git checkout -b feature/email-assistant-implementation
+
+# Step 1: Basic CLI
+git add <files>
+git commit -m "Step 1: Add basic CLI structure"
+git push
+
+# Step 2: State management (SAME BRANCH)
+git add <files>
+git commit -m "Step 2: Add state management"
+git push
+
+# Step 3: LangGraph nodes (SAME BRANCH)
+git add <files>
+git commit -m "Step 3: Implement LangGraph nodes"
+git push
+
+# ONE PR for all steps
+gh pr create --title "Complete Email Assistant Implementation"
+```
+
+### What NOT to Do
+
+❌ Don't create separate branches for each step
+❌ Don't create multiple PRs for related work
+❌ Don't merge partial implementations to main
+
+### Notes for Claude Code
+
+When I ask you to implement something with multiple steps:
+- Keep using the same branch throughout
+- Make incremental commits but push to the same PR
+- Update the PR description as you complete steps
+- Only create a new PR if working on completely unrelated features


### PR DESCRIPTION
## Summary
- Add Claude Code hooks configuration for project workflow
- Document single PR workflow preference
- Set up project-specific hooks to provide reminders

## What's included
- **`.claude/settings.local.json`**: Hook configuration
- **`.claude/hooks/enforce-single-pr.sh`**: Script to remind about single PR workflow
- **`WORKFLOW.md`**: Documentation of Git workflow preferences

## Purpose
These hooks help ensure consistent workflow practices by:
- Reminding when creating branches if one already exists
- Reminding about existing PRs when creating new ones
- Adding context about single PR preference to all prompts

## Test plan
- [ ] Verify hooks load properly in Claude Code
- [ ] Test that reminders appear when creating branches
- [ ] Confirm hooks don't block operations (only provide reminders)

🤖 Generated with [Claude Code](https://claude.ai/code)