### PR TITLE
feat: Step 2 - Simple Node Creation

### DIFF
--- a/email_assistant/cli.py
+++ b/email_assistant/cli.py
@@ -10,6 +10,12 @@ from email_assistant.models.state import (
     format_state_display,
     update_state,
 )
+from email_assistant.nodes import (
+    add_greeting_node,
+    add_signature_node,
+    format_subject_node,
+    validate_email_node,
+)
 
 app = typer.Typer(
     name="email-assistant",
@@ -119,6 +125,124 @@ def state_demo() -> None:
 
     console.print(table)
     console.print()
+
+
+@app.command()
+def node_demo() -> None:
+    """
+    Demonstrate LangGraph node concepts.
+
+    This command shows how nodes work in LangGraph:
+    1. Nodes are pure functions (state in → state out)
+    2. Nodes return partial updates
+    3. Nodes can be composed sequentially
+    4. Each node has a single responsibility
+
+    This is Step 2 of our learning journey!
+    """
+    console.print("\n[bold cyan]LangGraph Node Processing Demo[/bold cyan]\n")
+    console.print("This demo shows how nodes transform state in LangGraph.")
+    console.print("Nodes are the building blocks of graph workflows.\n")
+
+    # Create initial state
+    console.print("[yellow]Creating initial email state...[/yellow]")
+    state = create_initial_state(
+        subject="Project Update",
+        body="Here's the latest status on our project.",
+        recipient="john.doe@example.com",
+        email_type="business",
+    )
+
+    console.print(
+        Panel(
+            format_state_display(state),
+            title="Initial State",
+            border_style="dim",
+        )
+    )
+
+    # Apply format_subject_node
+    console.print("\n[yellow]Node 1: format_subject_node[/yellow]")
+    console.print("This node adds a prefix based on email type.")
+
+    subject_update = format_subject_node(state)
+    console.print(f"Node returned: {subject_update}")
+    state = update_state(state, **subject_update)
+
+    console.print(
+        Panel(
+            format_state_display(state),
+            title="After format_subject_node",
+            border_style="green",
+        )
+    )
+
+    # Apply add_greeting_node
+    console.print("\n[yellow]Node 2: add_greeting_node[/yellow]")
+    console.print("This node adds a personalized greeting to the body.")
+
+    greeting_update = add_greeting_node(state)
+    console.print(f"Node returned partial update with {len(greeting_update)} field(s)")
+    state = update_state(state, **greeting_update)
+
+    console.print(
+        Panel(
+            format_state_display(state),
+            title="After add_greeting_node",
+            border_style="blue",
+        )
+    )
+
+    # Apply add_signature_node
+    console.print("\n[yellow]Node 3: add_signature_node[/yellow]")
+    console.print("This node adds a signature to the email.")
+
+    # Add sender name to metadata for signature
+    state = update_state(state, metadata={"sender_name": "Alice Smith"})
+    signature_update = add_signature_node(state)
+    state = update_state(state, **signature_update)
+
+    console.print(
+        Panel(
+            format_state_display(state),
+            title="After add_signature_node",
+            border_style="magenta",
+        )
+    )
+
+    # Apply validate_email_node
+    console.print("\n[yellow]Node 4: validate_email_node[/yellow]")
+    console.print("This node validates the email and adds metadata.")
+
+    validation_update = validate_email_node(state)
+    state = update_state(state, **validation_update)
+
+    console.print(
+        Panel(
+            format_state_display(state),
+            title="After validate_email_node",
+            border_style="yellow",
+        )
+    )
+
+    # Show key concepts
+    console.print("\n[bold green]✓ Node Demo Complete![/bold green]")
+    console.print("\n[dim]Key Node Concepts:[/dim]")
+
+    table = Table(show_header=False, box=None)
+    table.add_column(style="cyan", no_wrap=True)
+    table.add_column()
+
+    table.add_row("1.", "Nodes are pure functions - same input gives same output")
+    table.add_row("2.", "Nodes return partial updates - only modified fields")
+    table.add_row("3.", "Nodes compose sequentially - output feeds next input")
+    table.add_row("4.", "Each node has single responsibility - do one thing well")
+    table.add_row("5.", "Nodes maintain immutability - never modify input state")
+
+    console.print(table)
+    console.print(
+        "\n[dim]Next: Step 3 will show how to connect nodes into a graph![/dim]\n"
+    )
 
 
 if __name__ == "__main__":

--- a/email_assistant/nodes/__init__.py
+++ b/email_assistant/nodes/__init__.py
@@ -1,0 +1,24 @@
+"""Nodes package for Email Assistant.
+
+This package contains LangGraph nodes - the fundamental processing units
+that transform state in a graph workflow.
+
+LangGraph Node Concepts:
+- Nodes are pure functions that take state and return state
+- Each node performs a specific transformation
+- Nodes can be composed into graphs for complex workflows
+"""
+
+from email_assistant.nodes.basic_nodes import (
+    add_greeting_node,
+    add_signature_node,
+    format_subject_node,
+    validate_email_node,
+)
+
+__all__ = [
+    "format_subject_node",
+    "add_greeting_node",
+    "add_signature_node",
+    "validate_email_node",
+]

--- a/email_assistant/nodes/basic_nodes.py
+++ b/email_assistant/nodes/basic_nodes.py
@@ -1,0 +1,271 @@
+"""Basic LangGraph nodes for email processing.
+
+This module contains simple nodes that demonstrate fundamental LangGraph concepts:
+1. Node function signatures (state in → state out)
+2. Pure functions with no side effects
+3. Partial state updates
+4. Immutability principles
+
+Each node is a building block that can be composed into larger graphs.
+"""
+
+from datetime import datetime
+from typing import Any
+
+from email_assistant.models.state import EmailState
+
+
+def format_subject_node(state: EmailState) -> dict[str, Any]:
+    """
+    Format the email subject based on email type.
+
+    This node demonstrates:
+    - Reading from state
+    - Conditional logic based on state values
+    - Returning partial updates (only subject field)
+
+    LangGraph Pattern:
+    - Input: Complete EmailState
+    - Output: Partial state update with only modified fields
+    - Pure function: Same input always produces same output
+
+    Args:
+        state: Current email state
+
+    Returns:
+        Dictionary with updated subject field
+    """
+    email_type = state.get("email_type", "other")
+    subject = state.get("subject", "")
+
+    # Skip if subject is empty
+    if not subject:
+        return {}
+
+    # Format based on email type
+    if email_type == "business":
+        formatted = f"[BUSINESS] {subject}"
+    elif email_type == "support":
+        formatted = f"[TICKET] {subject}"
+    elif email_type == "personal":
+        formatted = f"Personal: {subject}"
+    else:
+        formatted = subject
+
+    # Return only the field we modified
+    return {"subject": formatted}
+
+
+def add_greeting_node(state: EmailState) -> dict[str, Any]:
+    """
+    Add a personalized greeting to the email body.
+
+    This node demonstrates:
+    - Building content based on state
+    - String manipulation
+    - Preserving existing content
+
+    LangGraph Pattern:
+    - Nodes should be composable
+    - Each node does one thing well
+    - Maintains immutability
+
+    Args:
+        state: Current email state
+
+    Returns:
+        Dictionary with updated body field
+    """
+    recipient = state.get("recipient", "")
+    body = state.get("body", "")
+    email_type = state.get("email_type", "other")
+
+    # Extract name from email if possible
+    if recipient and "@" in recipient:
+        name = recipient.split("@")[0].replace(".", " ").title()
+    else:
+        name = "there"
+
+    # Choose greeting based on email type
+    if email_type == "business":
+        greeting = f"Dear {name},\n\n"
+    elif email_type == "support":
+        greeting = f"Hello {name},\n\nThank you for contacting support.\n\n"
+    elif email_type == "personal":
+        greeting = f"Hi {name}!\n\n"
+    else:
+        greeting = f"Hello {name},\n\n"
+
+    # Prepend greeting to body
+    updated_body = greeting + body
+
+    return {"body": updated_body}
+
+
+def add_signature_node(state: EmailState) -> dict[str, Any]:
+    """
+    Add a signature to the email body.
+
+    This node demonstrates:
+    - Appending content to existing state
+    - Using metadata to customize behavior
+    - Time-based content generation
+
+    LangGraph Pattern:
+    - Nodes can use any field from state
+    - Metadata field allows for extensibility
+    - Keep transformations simple and focused
+
+    Args:
+        state: Current email state
+
+    Returns:
+        Dictionary with updated body field
+    """
+    body = state.get("body", "")
+    email_type = state.get("email_type", "other")
+    metadata = state.get("metadata", {})
+
+    # Get sender name from metadata or use default
+    sender_name = (
+        metadata.get("sender_name", "Email Assistant")
+        if metadata
+        else "Email Assistant"
+    )
+
+    # Create signature based on email type
+    if email_type == "business":
+        signature = (
+            f"\n\nBest regards,\n{sender_name}\n{datetime.now().strftime('%Y-%m-%d')}"
+        )
+    elif email_type == "support":
+        signature = f"\n\nSincerely,\n{sender_name}\nSupport Team"
+    elif email_type == "personal":
+        signature = f"\n\nCheers,\n{sender_name}"
+    else:
+        signature = f"\n\nRegards,\n{sender_name}"
+
+    # Append signature to body
+    updated_body = body + signature
+
+    return {"body": updated_body}
+
+
+def validate_email_node(state: EmailState) -> dict[str, Any]:
+    """
+    Validate email fields and add validation metadata.
+
+    This node demonstrates:
+    - State validation
+    - Adding metadata about processing
+    - Error handling patterns
+
+    LangGraph Pattern:
+    - Nodes can validate and enrich state
+    - Metadata is useful for tracking processing
+    - Nodes should handle edge cases gracefully
+
+    Args:
+        state: Current email state
+
+    Returns:
+        Dictionary with updated metadata field
+    """
+    validation_results: dict[str, Any] = {
+        "validated_at": datetime.now().isoformat(),
+        "validation_passed": True,
+        "issues": [],
+    }
+    issues: list[str] = []
+
+    # Check required fields
+    if not state.get("recipient"):
+        validation_results["validation_passed"] = False
+        issues.append("Missing recipient")
+    elif "@" not in state.get("recipient", ""):
+        validation_results["validation_passed"] = False
+        issues.append("Invalid recipient email format")
+
+    if not state.get("subject"):
+        issues.append("Missing subject")
+
+    if not state.get("body"):
+        issues.append("Missing body")
+
+    # Check for reasonable lengths
+    subject = state.get("subject", "")
+    if len(subject) > 200:
+        issues.append("Subject too long (>200 chars)")
+
+    body = state.get("body", "")
+    if len(body) > 50000:
+        issues.append("Body too long (>50000 chars)")
+
+    validation_results["issues"] = issues
+
+    # Merge with existing metadata
+    current_metadata = state.get("metadata", {}) or {}
+    updated_metadata = {
+        **current_metadata,
+        "validation": validation_results,
+    }
+
+    return {"metadata": updated_metadata}
+
+
+def uppercase_subject_node(state: EmailState) -> dict[str, Any]:
+    """
+    Convert email subject to uppercase.
+
+    This is a simple demonstration node showing:
+    - Minimal transformation
+    - Single responsibility
+    - Easy testability
+
+    Args:
+        state: Current email state
+
+    Returns:
+        Dictionary with uppercase subject
+    """
+    subject = state.get("subject", "")
+    if subject:
+        return {"subject": subject.upper()}
+    return {}
+
+
+def word_count_node(state: EmailState) -> dict[str, Any]:
+    """
+    Add word count statistics to metadata.
+
+    This node demonstrates:
+    - Analyzing state without modifying core fields
+    - Enriching metadata with computed values
+    - Read-only operations on state
+
+    Args:
+        state: Current email state
+
+    Returns:
+        Dictionary with updated metadata containing word counts
+    """
+    subject = state.get("subject", "")
+    body = state.get("body", "")
+
+    # Calculate word counts
+    subject_words = len(subject.split()) if subject else 0
+    body_words = len(body.split()) if body else 0
+
+    # Add statistics to metadata
+    current_metadata = state.get("metadata", {}) or {}
+    updated_metadata = {
+        **current_metadata,
+        "statistics": {
+            "subject_word_count": subject_words,
+            "body_word_count": body_words,
+            "total_word_count": subject_words + body_words,
+            "calculated_at": datetime.now().isoformat(),
+        },
+    }
+
+    return {"metadata": updated_metadata}

--- a/tests/unit/nodes/__init__.py
+++ b/tests/unit/nodes/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for nodes package."""

--- a/tests/unit/nodes/test_basic_nodes.py
+++ b/tests/unit/nodes/test_basic_nodes.py
@@ -1,0 +1,586 @@
+# type: ignore
+"""Unit tests for basic LangGraph nodes.
+
+These tests verify that our basic nodes follow LangGraph principles:
+1. Pure functions (deterministic output for given input)
+2. Partial state updates (return only modified fields)
+3. Immutability (don't modify input state)
+4. Proper error handling
+"""
+
+from datetime import datetime
+from unittest.mock import patch
+
+from email_assistant.models.state import create_initial_state
+from email_assistant.nodes.basic_nodes import (
+    add_greeting_node,
+    add_signature_node,
+    format_subject_node,
+    uppercase_subject_node,
+    validate_email_node,
+    word_count_node,
+)
+
+
+class TestFormatSubjectNode:
+    """Test the format_subject_node function."""
+
+    def test_business_email_formatting(self):
+        """Test that business emails get [BUSINESS] prefix."""
+        state = create_initial_state(
+            subject="Quarterly Report",
+            email_type="business",
+        )
+        result = format_subject_node(state)
+
+        assert result == {"subject": "[BUSINESS] Quarterly Report"}
+        # Verify original state is not modified (immutability)
+        assert state["subject"] == "Quarterly Report"
+
+    def test_support_email_formatting(self):
+        """Test that support emails get [TICKET] prefix."""
+        state = create_initial_state(
+            subject="Login Issue",
+            email_type="support",
+        )
+        result = format_subject_node(state)
+
+        assert result == {"subject": "[TICKET] Login Issue"}
+
+    def test_personal_email_formatting(self):
+        """Test that personal emails get Personal: prefix."""
+        state = create_initial_state(
+            subject="Weekend Plans",
+            email_type="personal",
+        )
+        result = format_subject_node(state)
+
+        assert result == {"subject": "Personal: Weekend Plans"}
+
+    def test_other_email_type_unchanged(self):
+        """Test that 'other' type emails remain unchanged."""
+        state = create_initial_state(
+            subject="General Information",
+            email_type="other",
+        )
+        result = format_subject_node(state)
+
+        assert result == {"subject": "General Information"}
+
+    def test_empty_subject_returns_empty_dict(self):
+        """Test that empty subject returns empty update (no changes)."""
+        state = create_initial_state(
+            subject="",
+            email_type="business",
+        )
+        result = format_subject_node(state)
+
+        assert result == {}
+
+    def test_partial_update_pattern(self):
+        """Test that node returns only the field it modifies."""
+        state = create_initial_state(
+            subject="Test",
+            body="Some content",
+            recipient="test@example.com",
+            email_type="business",
+        )
+        result = format_subject_node(state)
+
+        # Should only return subject field, not other fields
+        assert "subject" in result
+        assert "body" not in result
+        assert "recipient" not in result
+        assert len(result) == 1
+
+
+class TestAddGreetingNode:
+    """Test the add_greeting_node function."""
+
+    def test_business_greeting(self):
+        """Test business email greeting format."""
+        state = create_initial_state(
+            recipient="john.doe@example.com",
+            body="Meeting scheduled for tomorrow.",
+            email_type="business",
+        )
+        result = add_greeting_node(state)
+
+        expected_body = "Dear John Doe,\n\nMeeting scheduled for tomorrow."
+        assert result == {"body": expected_body}
+
+    def test_support_greeting(self):
+        """Test support email greeting format."""
+        state = create_initial_state(
+            recipient="alice.smith@example.com",
+            body="We'll look into this issue.",
+            email_type="support",
+        )
+        result = add_greeting_node(state)
+
+        expected_body = (
+            "Hello Alice Smith,\n\nThank you for contacting support.\n\n"
+            "We'll look into this issue."
+        )
+        assert result == {"body": expected_body}
+
+    def test_personal_greeting(self):
+        """Test personal email greeting format."""
+        state = create_initial_state(
+            recipient="bob@example.com",
+            body="How have you been?",
+            email_type="personal",
+        )
+        result = add_greeting_node(state)
+
+        expected_body = "Hi Bob!\n\nHow have you been?"
+        assert result == {"body": expected_body}
+
+    def test_other_greeting(self):
+        """Test default greeting for 'other' type."""
+        state = create_initial_state(
+            recipient="user@example.com",
+            body="Information attached.",
+            email_type="other",
+        )
+        result = add_greeting_node(state)
+
+        expected_body = "Hello User,\n\nInformation attached."
+        assert result == {"body": expected_body}
+
+    def test_no_recipient_uses_default_name(self):
+        """Test greeting when recipient is empty."""
+        state = create_initial_state(
+            recipient="",
+            body="Content here.",
+            email_type="business",
+        )
+        result = add_greeting_node(state)
+
+        expected_body = "Dear there,\n\nContent here."
+        assert result == {"body": expected_body}
+
+    def test_preserves_existing_body(self):
+        """Test that existing body content is preserved."""
+        state = create_initial_state(
+            recipient="test@example.com",
+            body="Line 1\nLine 2\nLine 3",
+            email_type="personal",
+        )
+        result = add_greeting_node(state)
+
+        assert "Line 1\nLine 2\nLine 3" in result["body"]
+        assert result["body"].startswith("Hi Test!")
+
+
+class TestAddSignatureNode:
+    """Test the add_signature_node function."""
+
+    @patch("email_assistant.nodes.basic_nodes.datetime")
+    def test_business_signature(self, mock_datetime):
+        """Test business email signature format."""
+        mock_datetime.now.return_value.strftime.return_value = "2024-01-15"
+
+        state = create_initial_state(
+            body="Email content here.",
+            email_type="business",
+        )
+        state["metadata"] = {"sender_name": "John Smith"}
+
+        result = add_signature_node(state)
+
+        expected_body = "Email content here.\n\nBest regards,\nJohn Smith\n2024-01-15"
+        assert result == {"body": expected_body}
+
+    def test_support_signature(self):
+        """Test support email signature format."""
+        state = create_initial_state(
+            body="Your issue has been resolved.",
+            email_type="support",
+        )
+        state["metadata"] = {"sender_name": "Support Agent"}
+
+        result = add_signature_node(state)
+
+        expected_body = (
+            "Your issue has been resolved.\n\nSincerely,\nSupport Agent\nSupport Team"
+        )
+        assert result == {"body": expected_body}
+
+    def test_personal_signature(self):
+        """Test personal email signature format."""
+        state = create_initial_state(
+            body="See you soon!",
+            email_type="personal",
+        )
+        state["metadata"] = {"sender_name": "Alice"}
+
+        result = add_signature_node(state)
+
+        expected_body = "See you soon!\n\nCheers,\nAlice"
+        assert result == {"body": expected_body}
+
+    def test_default_sender_name(self):
+        """Test that default sender name is used when not in metadata."""
+        state = create_initial_state(
+            body="Content.",
+            email_type="other",
+        )
+
+        result = add_signature_node(state)
+
+        expected_body = "Content.\n\nRegards,\nEmail Assistant"
+        assert result == {"body": expected_body}
+
+    def test_appends_to_existing_body(self):
+        """Test that signature is appended to existing body."""
+        state = create_initial_state(
+            body="First paragraph.\n\nSecond paragraph.",
+            email_type="personal",
+        )
+        state["metadata"] = {"sender_name": "Bob"}
+
+        result = add_signature_node(state)
+
+        assert result["body"].startswith("First paragraph.\n\nSecond paragraph.")
+        assert result["body"].endswith("\n\nCheers,\nBob")
+
+
+class TestValidateEmailNode:
+    """Test the validate_email_node function."""
+
+    def test_valid_email_passes_validation(self):
+        """Test that a complete valid email passes validation."""
+        state = create_initial_state(
+            subject="Test Subject",
+            body="Test body content",
+            recipient="valid@example.com",
+            email_type="business",
+        )
+
+        result = validate_email_node(state)
+
+        assert "metadata" in result
+        validation = result["metadata"]["validation"]
+        assert validation["validation_passed"] is True
+        assert validation["issues"] == []
+
+    def test_missing_recipient_fails_validation(self):
+        """Test that missing recipient fails validation."""
+        state = create_initial_state(
+            subject="Test",
+            body="Body",
+            recipient="",
+        )
+
+        result = validate_email_node(state)
+
+        validation = result["metadata"]["validation"]
+        assert validation["validation_passed"] is False
+        assert "Missing recipient" in validation["issues"]
+
+    def test_invalid_email_format_fails_validation(self):
+        """Test that invalid email format fails validation."""
+        state = create_initial_state(
+            subject="Test",
+            body="Body",
+            recipient="not-an-email",
+        )
+
+        result = validate_email_node(state)
+
+        validation = result["metadata"]["validation"]
+        assert validation["validation_passed"] is False
+        assert "Invalid recipient email format" in validation["issues"]
+
+    def test_missing_subject_warning(self):
+        """Test that missing subject adds a warning but doesn't fail."""
+        state = create_initial_state(
+            subject="",
+            body="Body",
+            recipient="test@example.com",
+        )
+
+        result = validate_email_node(state)
+
+        validation = result["metadata"]["validation"]
+        assert "Missing subject" in validation["issues"]
+        # Missing subject doesn't fail validation entirely
+        assert validation["validation_passed"] is True
+
+    def test_missing_body_warning(self):
+        """Test that missing body adds a warning."""
+        state = create_initial_state(
+            subject="Subject",
+            body="",
+            recipient="test@example.com",
+        )
+
+        result = validate_email_node(state)
+
+        validation = result["metadata"]["validation"]
+        assert "Missing body" in validation["issues"]
+
+    def test_subject_too_long_warning(self):
+        """Test that overly long subject adds a warning."""
+        state = create_initial_state(
+            subject="x" * 201,  # 201 characters
+            body="Body",
+            recipient="test@example.com",
+        )
+
+        result = validate_email_node(state)
+
+        validation = result["metadata"]["validation"]
+        assert "Subject too long (>200 chars)" in validation["issues"]
+
+    def test_body_too_long_warning(self):
+        """Test that overly long body adds a warning."""
+        state = create_initial_state(
+            subject="Subject",
+            body="x" * 50001,  # 50001 characters
+            recipient="test@example.com",
+        )
+
+        result = validate_email_node(state)
+
+        validation = result["metadata"]["validation"]
+        assert "Body too long (>50000 chars)" in validation["issues"]
+
+    def test_metadata_timestamp_added(self):
+        """Test that validation timestamp is added to metadata."""
+        state = create_initial_state(
+            subject="Test",
+            body="Body",
+            recipient="test@example.com",
+        )
+
+        result = validate_email_node(state)
+
+        validation = result["metadata"]["validation"]
+        assert "validated_at" in validation
+        # Should be an ISO format timestamp
+        datetime.fromisoformat(validation["validated_at"])
+
+    def test_preserves_existing_metadata(self):
+        """Test that existing metadata is preserved."""
+        state = create_initial_state(
+            subject="Test",
+            body="Body",
+            recipient="test@example.com",
+        )
+        state["metadata"] = {"existing_key": "existing_value"}
+
+        result = validate_email_node(state)
+
+        assert "existing_key" in result["metadata"]
+        assert result["metadata"]["existing_key"] == "existing_value"
+        assert "validation" in result["metadata"]
+
+
+class TestUppercaseSubjectNode:
+    """Test the uppercase_subject_node function."""
+
+    def test_converts_to_uppercase(self):
+        """Test that subject is converted to uppercase."""
+        state = create_initial_state(
+            subject="Hello World",
+        )
+
+        result = uppercase_subject_node(state)
+
+        assert result == {"subject": "HELLO WORLD"}
+
+    def test_handles_mixed_case(self):
+        """Test handling of mixed case input."""
+        state = create_initial_state(
+            subject="MiXeD CaSe TeXt",
+        )
+
+        result = uppercase_subject_node(state)
+
+        assert result == {"subject": "MIXED CASE TEXT"}
+
+    def test_empty_subject_returns_empty_dict(self):
+        """Test that empty subject returns no updates."""
+        state = create_initial_state(
+            subject="",
+        )
+
+        result = uppercase_subject_node(state)
+
+        assert result == {}
+
+    def test_already_uppercase_unchanged(self):
+        """Test that already uppercase text still returns update."""
+        state = create_initial_state(
+            subject="ALREADY UPPERCASE",
+        )
+
+        result = uppercase_subject_node(state)
+
+        # Should still return the field even if unchanged
+        assert result == {"subject": "ALREADY UPPERCASE"}
+
+
+class TestWordCountNode:
+    """Test the word_count_node function."""
+
+    def test_counts_subject_words(self):
+        """Test word counting in subject."""
+        state = create_initial_state(
+            subject="This is a test",
+            body="",
+        )
+
+        result = word_count_node(state)
+
+        stats = result["metadata"]["statistics"]
+        assert stats["subject_word_count"] == 4
+        assert stats["body_word_count"] == 0
+        assert stats["total_word_count"] == 4
+
+    def test_counts_body_words(self):
+        """Test word counting in body."""
+        state = create_initial_state(
+            subject="",
+            body="The quick brown fox jumps over the lazy dog",
+        )
+
+        result = word_count_node(state)
+
+        stats = result["metadata"]["statistics"]
+        assert stats["subject_word_count"] == 0
+        assert stats["body_word_count"] == 9
+        assert stats["total_word_count"] == 9
+
+    def test_counts_both_fields(self):
+        """Test word counting in both subject and body."""
+        state = create_initial_state(
+            subject="Email Subject Here",
+            body="This is the email body with some content.",
+        )
+
+        result = word_count_node(state)
+
+        stats = result["metadata"]["statistics"]
+        assert stats["subject_word_count"] == 3
+        assert stats["body_word_count"] == 8
+        assert stats["total_word_count"] == 11
+
+    def test_handles_empty_fields(self):
+        """Test handling of empty subject and body."""
+        state = create_initial_state(
+            subject="",
+            body="",
+        )
+
+        result = word_count_node(state)
+
+        stats = result["metadata"]["statistics"]
+        assert stats["subject_word_count"] == 0
+        assert stats["body_word_count"] == 0
+        assert stats["total_word_count"] == 0
+
+    def test_handles_multiline_text(self):
+        """Test word counting with multiline text."""
+        state = create_initial_state(
+            subject="Subject Line",
+            body="Line one here.\nLine two here.\nLine three.",
+        )
+
+        result = word_count_node(state)
+
+        stats = result["metadata"]["statistics"]
+        assert stats["subject_word_count"] == 2
+        assert stats["body_word_count"] == 8
+        assert stats["total_word_count"] == 10
+
+    def test_adds_timestamp(self):
+        """Test that calculation timestamp is added."""
+        state = create_initial_state(
+            subject="Test",
+            body="Body",
+        )
+
+        result = word_count_node(state)
+
+        stats = result["metadata"]["statistics"]
+        assert "calculated_at" in stats
+        # Should be an ISO format timestamp
+        datetime.fromisoformat(stats["calculated_at"])
+
+    def test_preserves_existing_metadata(self):
+        """Test that existing metadata is preserved."""
+        state = create_initial_state(
+            subject="Test",
+            body="Body",
+        )
+        state["metadata"] = {"other_key": "other_value"}
+
+        result = word_count_node(state)
+
+        assert "other_key" in result["metadata"]
+        assert result["metadata"]["other_key"] == "other_value"
+        assert "statistics" in result["metadata"]
+
+
+class TestNodeImmutability:
+    """Test that all nodes maintain immutability principle."""
+
+    def test_nodes_dont_modify_input_state(self):
+        """Test that nodes don't modify the input state object."""
+        original_state = create_initial_state(
+            subject="Original Subject",
+            body="Original Body",
+            recipient="test@example.com",
+            email_type="business",
+        )
+        original_state["metadata"] = {"test": "value"}
+
+        # Create a copy to compare later
+        state_copy = dict(original_state)
+
+        # Run all nodes - they should not modify the input
+        format_subject_node(original_state)
+        add_greeting_node(original_state)
+        add_signature_node(original_state)
+        validate_email_node(original_state)
+        uppercase_subject_node(original_state)
+        word_count_node(original_state)
+
+        # Original state should be unchanged
+        assert original_state == state_copy
+        assert original_state["subject"] == "Original Subject"
+        assert original_state["body"] == "Original Body"
+        assert original_state["recipient"] == "test@example.com"
+        assert original_state["metadata"] == {"test": "value"}
+
+
+class TestNodePureFunctions:
+    """Test that nodes behave as pure functions."""
+
+    def test_deterministic_output(self):
+        """Test that same input always produces same output."""
+        state = create_initial_state(
+            subject="Test Subject",
+            body="Test Body",
+            recipient="test@example.com",
+            email_type="business",
+        )
+
+        # Run each node multiple times with same input
+        result1 = format_subject_node(state)
+        result2 = format_subject_node(state)
+        assert result1 == result2
+
+        result1 = add_greeting_node(state)
+        result2 = add_greeting_node(state)
+        assert result1 == result2
+
+        result1 = uppercase_subject_node(state)
+        result2 = uppercase_subject_node(state)
+        assert result1 == result2
+
+        # Note: Some nodes use datetime.now() so they're not perfectly pure,
+        # but the logic should be deterministic


### PR DESCRIPTION
## Summary
- Implements Step 2 of the LangGraph learning journey
- Adds 6 example nodes demonstrating core LangGraph concepts
- Includes comprehensive test coverage (39 tests, all passing)

## Changes
- **New nodes in `basic_nodes.py`:**
  - `format_subject_node` - Demonstrates conditional logic and partial updates
  - `add_greeting_node` - Shows content building and preservation
  - `add_signature_node` - Uses metadata for customization
  - `validate_email_node` - Validates state and enriches metadata
  - `uppercase_subject_node` - Simple transformation example
  - `word_count_node` - Read-only analysis without modifying core fields

- **CLI enhancements:**
  - Added `node_demo` command to interactively demonstrate node functionality
  - Shows how nodes transform state step by step

- **Test coverage:**
  - Comprehensive unit tests for all nodes
  - Tests for immutability, pure functions, and partial updates
  - All tests passing

## Key LangGraph Concepts Demonstrated
1. **Pure Functions** - Nodes produce deterministic output
2. **Partial State Updates** - Nodes return only modified fields
3. **Immutability** - Nodes never modify input state
4. **Single Responsibility** - Each node does one thing well
5. **Composability** - Nodes can be chained together

## Test Results
```
============================== 39 passed in 1.09s ==============================
```

## Next Steps
Step 3 will connect these nodes into a linear graph flow, demonstrating how to build actual workflows with LangGraph.

🤖 Generated with [Claude Code](https://claude.ai/code)